### PR TITLE
more efficient image loading

### DIFF
--- a/src/components/EventCard.astro
+++ b/src/components/EventCard.astro
@@ -1,6 +1,6 @@
 ---
 import { Image } from "astro:assets";
-const { event, soonest } = Astro.props;
+const { event, soonest, eager } = Astro.props;
 import { API_URL } from "@/lib/directus";
 import { Calendar } from "lucide-react";
 ---
@@ -19,6 +19,7 @@ import { Calendar } from "lucide-react";
           width="512"
           height="512"
           class="object-scale-down mx-auto rounded-lg"
+          loading={eager ? "eager" : "lazy"}
         />
       )
     }

--- a/src/layouts/EventsLayout.astro
+++ b/src/layouts/EventsLayout.astro
@@ -4,12 +4,10 @@ import Footer from "../components/Footer.astro";
 import { Image } from "astro:assets";
 import icon from "/favicon.ico";
 import { ViewTransitions } from "astro:transitions";
-import { slide } from "astro:transitions";
 import Navbar from "@/components/Navbar.astro";
 const { event } = Astro.props;
 import { API_URL } from "@/lib/directus";
 import { Calendar, Clock, MapPin } from "lucide-react";
-import BannerCarousel from "@/components/BannerCarousel";
 ---
 
 <html lang="en">
@@ -143,12 +141,10 @@ import BannerCarousel from "@/components/BannerCarousel";
         </div>
         {
           event.image && (
-            <Image
-              src={`${API_URL}/assets/${event.image}?width=512`}
+            <img
+              src={`${API_URL}/assets/${event.image}?width=512&format=webp`}
               alt={event.title}
               transition:name={event.slug}
-              width={512}
-              height={512}
               class="hidden md:flex rounded-xl w-auto"
               loading="eager"
             />

--- a/src/layouts/EventsLayout.astro
+++ b/src/layouts/EventsLayout.astro
@@ -150,6 +150,7 @@ import BannerCarousel from "@/components/BannerCarousel";
               width={512}
               height={512}
               class="hidden md:flex rounded-xl w-auto"
+              loading="eager"
             />
           )
         }

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -7,10 +7,10 @@ import { readItems } from "@directus/sdk";
 import { DateTime } from "luxon";
 
 // TODO: Add pagination
-import { PreviousEvents } from '@/components/PreviousEvents';
+import { PreviousEvents } from "@/components/PreviousEvents";
 
 const events = await directus.request(
-readItems("events", {
+  readItems("events", {
     fields: ["*"],
     sort: ["-start_datetime"],
     filter: import.meta.env.DEV // Only show published events in prod. Drafted events can be previewed in localhost.
@@ -64,13 +64,13 @@ const upcomingEvents = events.filter(
       <div
         class={`${upcomingEvents.length != 0 ? "flex flex-col items-center" : "hidden"} sm:hidden`}
       >
-        {upcomingEvents.map((event) => <EventCard event={event} />)}
+        {upcomingEvents.map((event) => <EventCard event={event} eager />)}
       </div>
       <!-- One upcoming event case -->
       {
         upcomingEvents.length === 1 && (
           <div class={`hidden sm:flex flex-col items-center`}>
-            <EventCard event={upcomingEvents[0]} soonest />
+            <EventCard event={upcomingEvents[0]} soonest eager />
           </div>
         )
       }
@@ -79,7 +79,7 @@ const upcomingEvents = events.filter(
         upcomingEvents.length > 1 && (
           <div class={`hidden sm:grid grid-cols-2 gap-4`}>
             {upcomingEvents
-              .map((event) => <EventCard event={event} />)
+              .map((event) => <EventCard event={event} eager />)
               .reverse()}
           </div>
         )
@@ -87,11 +87,7 @@ const upcomingEvents = events.filter(
     </div>
     <!-- Previous Events -->
     <div class="flex flex-col my-6">
-      <h1
-        class="text-5xl font-bold mb-4 font-display"
-      >
-        Previous Events
-      </h1>
+      <h1 class="text-5xl font-bold mb-4 font-display">Previous Events</h1>
       <div class="mb-4">
         <PreviousEvents client:load />
       </div>


### PR DESCRIPTION
the loading attribute is whatevs but switching to a regular html img tag prevents astro from optimizing images and therefore storing two slightly different copies of the same images. this meant that originally, client had to download each image twice. this makes the site a lot smoother since clicking on events still shows the image correctly instead of needing to redownload